### PR TITLE
Fix excessive CPU usage with DispatchQueues

### DIFF
--- a/Source/Helpers/FrameGetter.swift
+++ b/Source/Helpers/FrameGetter.swift
@@ -45,7 +45,8 @@ struct FrameGetter: ViewModifier {
         content
             .background(
                 GeometryReader { proxy in
-                    Color.clear.preference(key: FrameRectPreferenceKey.self, value: proxy.frame(in: .global))
+                    EmptyView()
+                        .preference(key: FrameRectPreferenceKey.self, value: proxy.frame(in: .global))
                 }
             )
             .onPreferenceChange(FrameRectPreferenceKey.self) { rect in

--- a/Source/Helpers/FrameGetter.swift
+++ b/Source/Helpers/FrameGetter.swift
@@ -8,16 +8,15 @@
 
 import SwiftUI
 
-class ViewFrame: ObservableObject {
+@MainActor
+final class ViewFrame: ObservableObject {
 
     var startingRect: CGRect?
 
     @Published var frame: CGRect {
         willSet {
             if newValue.minY == 0 && newValue != startingRect {
-                DispatchQueue.main.async { [weak self] in
-                    self?.startingRect = newValue
-                }
+                self.startingRect = newValue
             }
         }
     }
@@ -33,6 +32,11 @@ extension View {
     }
 }
 
+struct FrameRectPreferenceKey: PreferenceKey {
+    static var defaultValue: CGRect = .zero
+    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {}
+}
+
 struct FrameGetter: ViewModifier {
 
     @Binding var frame: CGRect
@@ -40,16 +44,14 @@ struct FrameGetter: ViewModifier {
     func body(content: Content) -> some View {
         content
             .background(
-                GeometryReader { proxy -> AnyView in
-                    DispatchQueue.main.async {
-                        let rect = proxy.frame(in: .global)
-                        // This avoids an infinite layout loop
-                        if rect.integral != self.frame.integral {
-                            self.frame = rect
-                        }
-                    }
-                    return AnyView(EmptyView())
+                GeometryReader { proxy in
+                    Color.clear.preference(key: FrameRectPreferenceKey.self, value: proxy.frame(in: .global))
                 }
             )
+            .onPreferenceChange(FrameRectPreferenceKey.self) { rect in
+                if rect.integral != self.frame.integral {
+                    self.frame = rect
+                }
+            }
     }
 }


### PR DESCRIPTION
Since the original implementation was feeding values through DispatchQueues, SwiftUI ends up calling this so much the main thread spikes to 100% when nothing is happening. 

There is a better way to feed GeometryReader values, using PreferenceKey.

Also, this binds the ObservableObject `ViewFrame` class to the MainActor to avoid needing to feed values through a queue.

With this change, no longer observing 100% CPU spikes.