### PR TITLE
updated Introspect to SwiftUIIntrospect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,5 @@ fastlane/test_output
 iOSInjectionProject/
 
 # End of https://www.gitignore.io/api/swift,macos,carthage,cocoapods
+Package.resolved
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata

--- a/Example/Example/Examples/ColorScalingHeader.swift
+++ b/Example/Example/Examples/ColorScalingHeader.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 import ScalingHeaderScrollView
-import Introspect
+import SwiftUIIntrospect
 
 struct ColorScalingHeader: View {
 

--- a/Package.swift
+++ b/Package.swift
@@ -15,15 +15,13 @@ let package = Package(
             targets: ["ScalingHeaderScrollView"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-         .package(name: "Introspect", url: "https://github.com/siteline/SwiftUI-Introspect.git", from: "0.1.3"),
+        .package(url: "https://github.com/siteline/swiftui-introspect", from: "1.0.0"),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
-            name: "ScalingHeaderScrollView",
-            dependencies: ["Introspect"],
+            name: "ScalingHeaderScrollView", 
+            dependencies: [
+                .product(name: "SwiftUIIntrospect", package: "swiftui-introspect")],
             path: "Source"),
     ],
     swiftLanguageVersions: [.v5]

--- a/ScalingHeaderScrollView.podspec
+++ b/ScalingHeaderScrollView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "ScalingHeaderScrollView"
-  s.version          = "1.0.1"
+  s.version          = "1.0.2"
   s.summary          = "A scroll view with a sticky header which shrinks as you scroll. Written with SwiftUI."
 
   s.homepage         = 'https://github.com/exyte/ScalingHeaderScrollView.git'
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
      'Source/**/*.swift'
   ]
 
-  s.dependency 'Introspect'
+  s.dependency 'SwiftUIIntrospect'
 
 end

--- a/ScalingHeaderScrollView.podspec
+++ b/ScalingHeaderScrollView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "ScalingHeaderScrollView"
-  s.version          = "1.0.2"
+  s.version          = "1.0.3"
   s.summary          = "A scroll view with a sticky header which shrinks as you scroll. Written with SwiftUI."
 
   s.homepage         = 'https://github.com/exyte/ScalingHeaderScrollView.git'

--- a/ScalingHeaderScrollView.xcodeproj/project.pbxproj
+++ b/ScalingHeaderScrollView.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		5B704CB1280E907C0000C65D /* ScalingHeaderScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B704CAA280E907C0000C65D /* ScalingHeaderScrollView.swift */; };
 		5B704CB2280E907C0000C65D /* ScalingHeaderScrollViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B704CAC280E907C0000C65D /* ScalingHeaderScrollViewDelegate.swift */; };
 		5B704CB3280E907C0000C65D /* FrameGetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B704CAD280E907C0000C65D /* FrameGetter.swift */; };
-		5B704CB7280E91460000C65D /* Introspect in Frameworks */ = {isa = PBXBuildFile; productRef = 5B704CB6280E91460000C65D /* Introspect */; };
+		C8EE19672AB46B3600741F46 /* SwiftUIIntrospect in Frameworks */ = {isa = PBXBuildFile; productRef = C8EE19662AB46B3600741F46 /* SwiftUIIntrospect */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,7 +30,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5B704CB7280E91460000C65D /* Introspect in Frameworks */,
+				C8EE19672AB46B3600741F46 /* SwiftUIIntrospect in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -42,6 +42,7 @@
 			children = (
 				5B704CA7280E907C0000C65D /* Source */,
 				5B704C9E280E90640000C65D /* Products */,
+				C8EE19652AB46B3600741F46 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -74,6 +75,13 @@
 			path = Helpers;
 			sourceTree = "<group>";
 		};
+		C8EE19652AB46B3600741F46 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -103,7 +111,7 @@
 			);
 			name = ScalingHeaderScrollView;
 			packageProductDependencies = (
-				5B704CB6280E91460000C65D /* Introspect */,
+				C8EE19662AB46B3600741F46 /* SwiftUIIntrospect */,
 			);
 			productName = ScalingHeaderScrollView;
 			productReference = 5B704C9D280E90640000C65D /* ScalingHeaderScrollView.framework */;
@@ -220,7 +228,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -278,7 +286,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -303,6 +311,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -333,6 +342,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -380,16 +390,16 @@
 			repositoryURL = "https://github.com/siteline/SwiftUI-Introspect";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.4;
+				minimumVersion = 1.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		5B704CB6280E91460000C65D /* Introspect */ = {
+		C8EE19662AB46B3600741F46 /* SwiftUIIntrospect */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 5B704CB5280E91460000C65D /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
-			productName = Introspect;
+			productName = SwiftUIIntrospect;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ScalingHeaderScrollView.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ScalingHeaderScrollView.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/SwiftUI-Introspect",
       "state" : {
-        "revision" : "f2616860a41f9d9932da412a8978fec79c06fe24",
-        "version" : "0.1.4"
+        "revision" : "3ba734dd20faada0e3234b68e78db97005315f0e",
+        "version" : "1.0.0"
       }
     }
   ],

--- a/Source/AutosizingList.swift
+++ b/Source/AutosizingList.swift
@@ -23,7 +23,7 @@ public struct AutosizingList<Content: View>: View {
         List {
             content
         }
-        .introspectTableView { tableView in
+        .introspect(.list, on: .iOS(.v15), scope:.receiver) { tableView in
             tableView.backgroundColor = .clear
             tableView.isScrollEnabled = false
             tableContentHeight = tableView.contentSize.height

--- a/Source/Helpers/ScalingHeaderScrollViewDelegate.swift
+++ b/Source/Helpers/ScalingHeaderScrollViewDelegate.swift
@@ -14,11 +14,17 @@ final class ScalingHeaderScrollViewDelegate: NSObject, ObservableObject, UIScrol
     var didPullToLoadMore: () -> Void = { }
     var didScroll: () -> Void = {}
     var didEndDragging = {}
+    var didEndDecelerating = {}
+    var willEndDragging: (Double) -> Void = {_ in }
 
     // MARK: - UIScrollViewDelegate
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         didScroll()
+    }
+    
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        willEndDragging(velocity.y)
     }
     
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
@@ -35,5 +41,9 @@ final class ScalingHeaderScrollViewDelegate: NSObject, ObservableObject, UIScrol
 
     func scrollViewWillBeginDecelerating(_ scrollView: UIScrollView) {
         didEndDragging()
+    }
+
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        didEndDecelerating()
     }
 }

--- a/Source/ScalingHeaderScrollView.swift
+++ b/Source/ScalingHeaderScrollView.swift
@@ -7,7 +7,7 @@
 //
 
 import SwiftUI
-import Introspect
+import SwiftUIIntrospect
 
 public enum SnapHeaderState: Equatable {
     case expanded
@@ -195,7 +195,7 @@ public struct ScalingHeaderScrollView<Header: View, Content: View>: View {
                 .offset(y: -(contentFrame.startingRect?.maxY ?? UIScreen.main.bounds.height))
             }
             .animation(headerAnimation, value: shouldSnapTo)
-            .introspectScrollView { scrollView in
+            .introspect(.scrollView, on: .iOS(.v15, .v16, .v17), scope: .receiver) { scrollView in
                 configure(scrollView: scrollView)
             }
             .onAppear {


### PR DESCRIPTION
Hello,

this updates the SwiftUIIntrospect dependency to latest version, both for SPM and Cocoapods. Example was made to work. 
Motivation: SwiftUI apps usually use the latest version of SwiftUIIntrospect and the dependency in ScalingHeaderScrollView was fixed to under 1.0.0, which was creating a conflict at package resolution.
Note: if accepted and eventually merged, the commit will have to be tagged with same tag as podspec version (1.0.2)