### PR TITLE
Fix memory leak in latest iOS versions

### DIFF
--- a/Source/Helpers/ScalingHeaderScrollViewDelegate.swift
+++ b/Source/Helpers/ScalingHeaderScrollViewDelegate.swift
@@ -17,6 +17,9 @@ final class ScalingHeaderScrollViewDelegate: NSObject, ObservableObject, UIScrol
     var didEndDecelerating = {}
     var willEndDragging: (Double) -> Void = {_ in }
     var didReachBottom: () -> Void = {}
+    
+    // weak to prevent memory leaks on iOS > 17.0 with UIScrollView in ScalingHeaderScrollView
+    weak var uiScrollView: UIScrollView?
 
     // MARK: - UIScrollViewDelegate
 

--- a/Source/ScalingHeaderScrollView.swift
+++ b/Source/ScalingHeaderScrollView.swift
@@ -43,7 +43,7 @@ public struct ScalingHeaderScrollView<Header: View, Content: View>: View {
     @State private var pullToLoadMoreInProgress: Bool = false
 
     /// UIKit's UIScrollView
-    @State private var uiScrollView: UIScrollView?
+    private var uiScrollView: UIScrollView? { scrollViewDelegate.uiScrollView }
 
     /// Sets the opacity value for pull-to-load-more progress view
     @State private var pullToLoadOpacity: CGFloat = 1.0
@@ -299,7 +299,7 @@ public struct ScalingHeaderScrollView<Header: View, Content: View>: View {
         
         DispatchQueue.main.async {
             if uiScrollView != scrollView {
-                uiScrollView = scrollView
+                scrollViewDelegate.uiScrollView = scrollView
                 snapInitialScrollPosition()
             }
         }


### PR DESCRIPTION
In the latest versions of the system (> 17.0), the component causes a memory leak (did not occur in previous versions). This bug causes the application to freeze after some time of use. Especially if content of the comment is a map.

It is necessary to reference the UIScrollView as a weak reference. I took advantage of the existence of the delegate and added the reference there. I didn't want to create a new object specifically for holding the reference. The modification is minimal, but it works fine.