### PR TITLE
Bump swiftui-introspect to 1.3.0 to fix iOS 18 support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["ScalingHeaderScrollView"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/siteline/swiftui-introspect", from: "1.0.0"),
+        .package(url: "https://github.com/siteline/swiftui-introspect", from: "1.3.0"),
     ],
     targets: [
         .target(

--- a/ScalingHeaderScrollView.xcodeproj/project.pbxproj
+++ b/ScalingHeaderScrollView.xcodeproj/project.pbxproj
@@ -390,7 +390,7 @@
 			repositoryURL = "https://github.com/siteline/SwiftUI-Introspect";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 1.3.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ScalingHeaderScrollView.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ScalingHeaderScrollView.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,14 +1,15 @@
 {
+  "originHash" : "2794040049707bafa2a9bec79b485cba8bf59f5622c1ec745245b2b23dac011c",
   "pins" : [
     {
       "identity" : "swiftui-introspect",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/SwiftUI-Introspect",
       "state" : {
-        "revision" : "3ba734dd20faada0e3234b68e78db97005315f0e",
-        "version" : "1.0.0"
+        "revision" : "807f73ce09a9b9723f12385e592b4e0aaebd3336",
+        "version" : "1.3.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
Had a few issues getting this to work nicely on iOS 18 - installed the latest package and ran into this issue #62 

Have updated my project to use my fork and tested in iOS 18, seems to all work now. Not sure if/how you normally accept PRs but I hope this helps